### PR TITLE
Corrige scrollspy dos filtros da landing

### DIFF
--- a/app/assets/javascripts/landing.js
+++ b/app/assets/javascripts/landing.js
@@ -64,5 +64,16 @@ $(function() {
   $("#modal-sign-up.open-me").modal("show");
 
   // Ativa o Scrollspy do Twitter.
-  $("body").scrollspy({ target: ".filters", offset: 140 });
+  (function() {
+    var filtersScrollspyTarget = '.js-filters-scrollspy';
+    var filtersScrollspyOffset = $(filtersScrollspyTarget).outerHeight();
+
+    $(document.body).scrollspy({
+      target: filtersScrollspyTarget,
+      offset: filtersScrollspyOffset,
+      activeClass: 'filter-active',
+      selector: '.filter',
+      applyActiveToParent: false
+    });
+  })();
 });

--- a/app/views/landing/_filters.html.erb
+++ b/app/views/landing/_filters.html.erb
@@ -2,7 +2,7 @@
   Filtros da navegaçao.
 %>
 
-<div class="landing-filters">
+<div class="landing-filters js-filters-scrollspy">
   <div class="filters">
     <a class="filter landing-scroll" href="#segmentos">Segmentos</a>
     <a class="filter landing-scroll" href="#vantagens">Vantagens</a>

--- a/vendor/assets/javascripts/bootstrap-scrollspy.js
+++ b/vendor/assets/javascripts/bootstrap-scrollspy.js
@@ -1,152 +1,172 @@
-/* =============================================================
- * bootstrap-scrollspy.js v2.1.1
- * http://twitter.github.com/bootstrap/javascript.html#scrollspy
- * =============================================================
- * Copyright 2012 Twitter, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * ============================================================== */
+/* ========================================================================
+ * Bootstrap: scrollspy.js v3.3.6
+ * http://getbootstrap.com/javascript/#scrollspy
+ * ========================================================================
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * ======================================================================== */
 
 
-!function ($) {
++function ($) {
+  'use strict';
 
-  "use strict"; // jshint ;_;
-
-
- /* SCROLLSPY CLASS DEFINITION
-  * ========================== */
+  // SCROLLSPY CLASS DEFINITION
+  // ==========================
 
   function ScrollSpy(element, options) {
-    var process = $.proxy(this.process, this)
-      , $element = $(element).is('body') ? $(window) : $(element)
-      , href
-    this.options = $.extend({}, $.fn.scrollspy.defaults, options)
-    this.$scrollElement = $element.on('scroll.scroll-spy.data-api', process)
-    this.selector = (this.options.target
-      || ((href = $(element).attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
-      || '') + ' .filter'
-    this.$body = $('body')
+    this.$body          = $(document.body)
+    this.$scrollElement = $(element).is(document.body) ? $(window) : $(element)
+    this.options        = $.extend({}, ScrollSpy.DEFAULTS, options)
+    this.selector       = (this.options.target || '') + ' .nav li > a'
+    this.offsets        = []
+    this.targets        = []
+    this.activeTarget   = null
+    this.scrollHeight   = 0
+
+    this.$scrollElement.on('scroll.bs.scrollspy', $.proxy(this.process, this))
     this.refresh()
     this.process()
   }
 
-  ScrollSpy.prototype = {
+  ScrollSpy.VERSION  = '3.3.6'
 
-      constructor: ScrollSpy
+  ScrollSpy.DEFAULTS = {
+    offset: 10
+  }
 
-    , refresh: function () {
-        var self = this
-          , $targets
+  ScrollSpy.prototype.getScrollHeight = function () {
+    return this.$scrollElement[0].scrollHeight || Math.max(this.$body[0].scrollHeight, document.documentElement.scrollHeight)
+  }
 
-        this.offsets = $([])
-        this.targets = $([])
+  ScrollSpy.prototype.refresh = function () {
+    var that          = this
+    var offsetMethod  = 'offset'
+    var offsetBase    = 0
 
-        $targets = this.$body
-          .find(this.selector)
-          .map(function () {
-            var $el = $(this)
-              , href = $el.data('target') || $el.attr('href')
-              , $href = /^#\w/.test(href) && $(href)
-            return ( $href
-              && $href.length
-              && [[ $href.position().top, href ]] ) || null
-          })
-          .sort(function (a, b) { return a[0] - b[0] })
-          .each(function () {
-            self.offsets.push(this[0])
-            self.targets.push(this[1])
-          })
-      }
+    this.offsets      = []
+    this.targets      = []
+    this.scrollHeight = this.getScrollHeight()
 
-    , process: function () {
-        var scrollTop = this.$scrollElement.scrollTop() + this.options.offset
-            // O Scrollspy não funciona no FF devido ao html, body { height: 100%; } do sticky footer. Solução: https://github.com/P2000/bootstrap/commit/7e286a7f5cd7ddee7409ba15eacfb70e33ca6c2d
-          , scrollHeight = $(".main-wrapper")[0].scrollHeight || this.$scrollElement[0].scrollHeight || this.$body[0].scrollHeight
-          , maxScroll = scrollHeight - this.$scrollElement.height()
-          , offsets = this.offsets
-          , targets = this.targets
-          , activeTarget = this.activeTarget
-          , i
+    if (!$.isWindow(this.$scrollElement[0])) {
+      offsetMethod = 'position'
+      offsetBase   = this.$scrollElement.scrollTop()
+    }
 
-        if (scrollTop >= maxScroll) {
-          return activeTarget != (i = targets.last()[0])
-            && this.activate ( i )
-        }
+    this.$body
+      .find(this.selector)
+      .map(function () {
+        var $el   = $(this)
+        var href  = $el.data('target') || $el.attr('href')
+        var $href = /^#./.test(href) && $(href)
 
-        for (i = offsets.length; i--;) {
-          activeTarget != targets[i]
-            && scrollTop >= offsets[i]
-            && (!offsets[i + 1] || scrollTop <= offsets[i + 1])
-            && this.activate( targets[i] )
-        }
-      }
+        return ($href
+          && $href.length
+          && $href.is(':visible')
+          && [[$href[offsetMethod]().top + offsetBase, href]]) || null
+      })
+      .sort(function (a, b) { return a[0] - b[0] })
+      .each(function () {
+        that.offsets.push(this[0])
+        that.targets.push(this[1])
+      })
+  }
 
-    , activate: function (target) {
-        var active
-          , selector
+  ScrollSpy.prototype.process = function () {
+    var scrollTop    = this.$scrollElement.scrollTop() + this.options.offset
+    var scrollHeight = this.getScrollHeight()
+    var maxScroll    = this.options.offset + scrollHeight - this.$scrollElement.height()
+    var offsets      = this.offsets
+    var targets      = this.targets
+    var activeTarget = this.activeTarget
+    var i
 
-        this.activeTarget = target
+    if (this.scrollHeight != scrollHeight) {
+      this.refresh()
+    }
 
-        $(this.selector)
-          // .parent('.filter-active')
-          .removeClass('filter-active')
+    if (scrollTop >= maxScroll) {
+      return activeTarget != (i = targets[targets.length - 1]) && this.activate(i)
+    }
 
-        selector = this.selector
-          + '[data-target="' + target + '"],'
-          + this.selector + '[href="' + target + '"]'
+    if (activeTarget && scrollTop < offsets[0]) {
+      this.activeTarget = null
+      return this.clear()
+    }
 
-        active = $(selector)
-          // .parent('.filters')
-          .addClass('filter-active')
+    for (i = offsets.length; i--;) {
+      activeTarget != targets[i]
+        && scrollTop >= offsets[i]
+        && (offsets[i + 1] === undefined || scrollTop < offsets[i + 1])
+        && this.activate(targets[i])
+    }
+  }
 
-        if (active.parent('.dropdown-menu').length)  {
-          active = active.closest('li.dropdown').addClass('active')
-        }
+  ScrollSpy.prototype.activate = function (target) {
+    this.activeTarget = target
 
-        active.trigger('activate')
-      }
+    this.clear()
 
+    var selector = this.selector +
+      '[data-target="' + target + '"],' +
+      this.selector + '[href="' + target + '"]'
+
+    var active = $(selector)
+      .parents('li')
+      .addClass('active')
+
+    if (active.parent('.dropdown-menu').length) {
+      active = active
+        .closest('li.dropdown')
+        .addClass('active')
+    }
+
+    active.trigger('activate.bs.scrollspy')
+  }
+
+  ScrollSpy.prototype.clear = function () {
+    $(this.selector)
+      .parentsUntil(this.options.target, '.active')
+      .removeClass('active')
   }
 
 
- /* SCROLLSPY PLUGIN DEFINITION
-  * =========================== */
+  // SCROLLSPY PLUGIN DEFINITION
+  // ===========================
 
-  $.fn.scrollspy = function (option) {
+  function Plugin(option) {
     return this.each(function () {
-      var $this = $(this)
-        , data = $this.data('scrollspy')
-        , options = typeof option == 'object' && option
-      if (!data) $this.data('scrollspy', (data = new ScrollSpy(this, options)))
+      var $this   = $(this)
+      var data    = $this.data('bs.scrollspy')
+      var options = typeof option == 'object' && option
+
+      if (!data) $this.data('bs.scrollspy', (data = new ScrollSpy(this, options)))
       if (typeof option == 'string') data[option]()
     })
   }
 
+  var old = $.fn.scrollspy
+
+  $.fn.scrollspy             = Plugin
   $.fn.scrollspy.Constructor = ScrollSpy
 
-  $.fn.scrollspy.defaults = {
-    offset: 10
+
+  // SCROLLSPY NO CONFLICT
+  // =====================
+
+  $.fn.scrollspy.noConflict = function () {
+    $.fn.scrollspy = old
+    return this
   }
 
 
- /* SCROLLSPY DATA-API
-  * ================== */
+  // SCROLLSPY DATA-API
+  // ==================
 
-  $(window).on('load', function () {
+  $(window).on('load.bs.scrollspy.data-api', function () {
     $('[data-spy="scroll"]').each(function () {
       var $spy = $(this)
-      $spy.scrollspy($spy.data())
+      Plugin.call($spy, $spy.data())
     })
   })
 
-}(window.jQuery);
+}(jQuery);

--- a/vendor/assets/javascripts/bootstrap-scrollspy.js
+++ b/vendor/assets/javascripts/bootstrap-scrollspy.js
@@ -17,7 +17,7 @@
     this.$body          = $(document.body)
     this.$scrollElement = $(element).is(document.body) ? $(window) : $(element)
     this.options        = $.extend({}, ScrollSpy.DEFAULTS, options)
-    this.selector       = (this.options.target || '') + ' .nav li > a'
+    this.selector       = (this.options.target || '') + ' ' + this.options.selector
     this.offsets        = []
     this.targets        = []
     this.activeTarget   = null
@@ -31,7 +31,13 @@
   ScrollSpy.VERSION  = '3.3.6'
 
   ScrollSpy.DEFAULTS = {
-    offset: 10
+    offset: 10,
+    // Classe que indica estado ativado.
+    activeClass: 'active',
+    // Seletor dos alvos.
+    selector: '.nav li > a',
+    // Indica se a classe de estado ativado deve ser aplicada ao pai do seletor (true) ou no próprio seletor (false).
+    applyActiveToParent: true
   }
 
   ScrollSpy.prototype.getScrollHeight = function () {
@@ -110,23 +116,35 @@
       '[data-target="' + target + '"],' +
       this.selector + '[href="' + target + '"]'
 
-    var active = $(selector)
-      .parents('li')
-      .addClass('active')
 
-    if (active.parent('.dropdown-menu').length) {
-      active = active
-        .closest('li.dropdown')
-        .addClass('active')
+    var $active = $(selector)
+
+    if (this.options.applyActiveToParent) {
+      $active
+        .parents('li')
+        .addClass(this.options.activeClass)
+
+      if ($active.parent('.dropdown-menu').length) {
+        $active = $active
+          .closest('li.dropdown')
+          .addClass(this.options.activeClass)
+      }
+    } else {
+      $active = $active.addClass(this.options.activeClass)
     }
 
-    active.trigger('activate.bs.scrollspy')
+    $active.trigger('activate.bs.scrollspy')
   }
 
   ScrollSpy.prototype.clear = function () {
-    $(this.selector)
-      .parentsUntil(this.options.target, '.active')
-      .removeClass('active')
+    var $selector = $(this.selector);
+
+    if (this.options.applyActiveToParent) {
+      $selector = $selector
+        .parentsUntil(this.options.target, '.' + this.options.activeClass)
+    }
+
+    $selector.removeClass(this.options.activeClass)
   }
 
 


### PR DESCRIPTION
Com a versão atualizada do Bootstrap Scrollspy e algumas modificações.

Fixes #27.

![depois](https://cloud.githubusercontent.com/assets/381395/11445293/c736bd1e-9509-11e5-8191-55b5bdf3f529.gif)
Com as modificações o scrollspy passa a ativar corretamente os itens dos filtros a medida que seu conteúdo vai aparecendo.

Depende da correção de #25 para o JS ser executado.