### PR TITLE
Adição de login via Google e variáveis de ambiente para autenticação …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ config/initializers/rails_footnotes.rb
 chromedriver.log
 solr/data/*
 solr/pids/*
+config/local_env.yml
 config/sunspot.yml
 .sass-cache/

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'mime-types'
 gem "mysql2"
 gem 'omniauth'
 gem 'omniauth-facebook'
+gem 'omniauth-google-oauth2'
 gem 'pusher'
 gem 'pagseguro', '~> 0.1.10'
 gem 'paperclip', '~> 2.7.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
     omniauth (1.1.4)
       hashie (>= 1.2, < 3)
       rack
-    omniauth-facebook (1.4.1)
+    omniauth-facebook (3.0.0)
       omniauth-oauth2 (~> 1.1.0)
     omniauth-google-oauth2 (0.2.6)
       omniauth (> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,9 @@ GEM
       rack
     omniauth-facebook (1.4.1)
       omniauth-oauth2 (~> 1.1.0)
+    omniauth-google-oauth2 (0.2.6)
+      omniauth (> 1.0)
+      omniauth-oauth2 (~> 1.1)
     omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
@@ -502,6 +505,7 @@ DEPENDENCIES
   oauth-plugin (~> 0.4.0)
   omniauth
   omniauth-facebook
+  omniauth-google-oauth2
   pagseguro (~> 0.1.10)
   paperclip (~> 2.7.5)
   premailer-rails

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -64,6 +64,11 @@
                 facebook_authentication_path(:state => { :friendship_invitation_token => @invitation.token }.to_json),
                 :class => "uibutton confirm large" %>
             </div>
+            <div class="fb-login">
+              <%= link_to "Entre com sua conta do Google",
+                google_authentication_path(),
+                :class => "uibutton confirm large" %>
+            </div>
             <p class="or-call">&minus; ou &minus;</p>
           <% end %>
         <% end %>

--- a/app/views/mobile/base/_form_sign_in.html.erb
+++ b/app/views/mobile/base/_form_sign_in.html.erb
@@ -37,6 +37,10 @@
       <%= link_to "Entre com sua conta do Facebook", facebook_authentication_path,
         :class => "facebook-sign-in-button" %>
     </div>
+    <div class="facebook-sign-in">
+      <%= link_to "Entre com sua conta do Google", google_authentication_path,
+        :class => "facebook-sign-in-button" %>
+    </div>
   </div>
   <div class="mobile-login-buttons clearfix">
     <%= link_to "Cadastrar-se", application_path(:anchor => "modal-sign-up"), :title => "Cadastrar-se",

--- a/app/views/shared/_dropdown_sign_in.html.erb
+++ b/app/views/shared/_dropdown_sign_in.html.erb
@@ -4,6 +4,10 @@
   <%= link_to "Entre com sua conta do Facebook", facebook_authentication_path,
     :class => "facebook-sign-in-button" %>
 </div>
+<div class="facebook-sign-in">
+  <%= link_to "Entre com sua conta do Google", google_authentication_path,
+    :class => "facebook-sign-in-button" %>
+</div>
 <hr class="header-separator">
 <div class="header-sign-in-recover">
   <%= link_to "Esqueceu sua senha? Clique aqui", recover_username_password_path, :class => "link-secondary" %>

--- a/app/views/shared/_form_sign_up.html.erb
+++ b/app/views/shared/_form_sign_up.html.erb
@@ -27,12 +27,18 @@
   </div>
   <div class="modal-body">
     <div class="modal-sign-up-section">
-      <p>Caso tenha uma conta no Facebook, você pode evitar o trabalho de
+      <p>Caso tenha uma conta no Facebook ou no Google, você pode evitar o trabalho de
         preencher formulários ao associar sua conta ao Redu. Desta forma, o
         cadastro é feito de forma automática.</p>
       <div class="facebook-sign-up">
         <%= link_to "Cadastre-se no Redu usando sua conta do Facebook",
           facebook_authentication_path(:state => fb_connect_invitation.to_json),
+          :class => "facebook-sign-up-button" %>
+        <span class="legend"><em>Opcional</em></span>
+      </div>
+      <div class="facebook-sign-up">
+        <%= link_to "Cadastre-se no Redu usando sua conta do Google",
+          google_authentication_path(),
           :class => "facebook-sign-up-button" %>
         <span class="legend"><em>Opcional</em></span>
       </div>

--- a/app/views/user_course_invitations/show.html.erb
+++ b/app/views/user_course_invitations/show.html.erb
@@ -86,6 +86,11 @@
               facebook_authentication_path(:state => { :invitation_token => @user_course_invitation.token }.to_json),
               :class => "uibutton confirm large" %>
           </div>
+          <div class="fb-login">
+            <%= link_to "Entre com sua conta do Gooogle",
+              google_authentication_path(),
+              :class => "uibutton confirm large" %>
+          </div>
           <p class="or-call">&minus; ou &minus;</p>
         <% end %>
       <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,14 @@ module Redu
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password, :password_confirmation]
 
+    # Local environment
+    config.before_configuration do
+      env_file = File.join(Rails.root, 'config', 'local_env.yml')
+      YAML.load(File.open(env_file)).each do |key, value|
+        ENV[key.to_s] = value
+      end if File.exists?(env_file)
+    end
+
     # S3 credentials
     if File.exists?("#{Rails.root}/config/s3.yml")
       config.s3_config = YAML.load_file("#{Rails.root}/config/s3.yml")

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,7 @@ Redu::Application.configure do
   config.action_dispatch.best_standards_support = :builtin
 
   # Nome e URL do app
-  config.url = "0.0.0.0:3000"
+  config.url = "localhost:3000"
   config.representer.default_url_options = {:host => "127.0.0.1:3000"}
 
   config.action_mailer.default_url_options = { :host => config.url }
@@ -62,8 +62,12 @@ Redu::Application.configure do
   # Configuração da aplicação em omniauth providers
   config.omniauth = {
     :facebook => {
-      :app_id => '142857189169463',
-      :app_secret => 'ea0f249a4df83b250c3364ccf097f35c'
+      :app_id => ENV["FACEBOOK_APP_ID_DEV"],
+      :app_secret => ENV["FACEBOOK_APP_SECRET_DEV"]
+    },
+    :google_oauth2 => {
+      :app_id => ENV["GOOGLE_APP_ID_DEV"],
+      :app_secret => ENV["GOOGLE_APP_SECRET_DEV"]
     }
   }
 

--- a/config/environments/performance.rb
+++ b/config/environments/performance.rb
@@ -90,8 +90,12 @@ Redu::Application.configure do
   # Configuração da aplicação em omniauth providers
   config.omniauth = {
     :facebook => {
-      :app_id => '142857189169463',
-      :app_secret => 'ea0f249a4df83b250c3364ccf097f35c'
+      :app_id => ENV["FACEBOOK_APP_ID_PERF"],
+      :app_secret => ENV["FACEBOOK_APP_SECRET_PERF"]
+    },
+    :google_oauth2 => {
+      :app_id => ENV["GOOGLE_APP_ID_PERF"],
+      :app_secret => ENV["GOOGLE_APP_SECRET_PERF"]
     }
   }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -63,8 +63,12 @@ Redu::Application.configure do
   # Configuração da aplicação em omniauth providers
   config.omniauth = {
     :facebook => {
-      :app_id => '142857189169463',
-      :app_secret => 'ea0f249a4df83b250c3364ccf097f35c'
+      :app_id => ENV["FACEBOOK_APP_ID_PROD"],
+      :app_secret => ENV["FACEBOOK_APP_SECRET_PROD"]
+    },
+    :google_oauth2 => {
+      :app_id => ENV["GOOGLE_APP_ID_PROD"],
+      :app_secret => ENV["GOOGLE_APP_SECRET_PROD"]
     }
   }
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,8 +63,12 @@ Redu::Application.configure do
   # Configuração da aplicação em omniauth providers
   config.omniauth = {
     :facebook => {
-      :app_id => '142857189169463',
-      :app_secret => 'ea0f249a4df83b250c3364ccf097f35c'
+      :app_id => ENV["FACEBOOK_APP_ID_TEST"],
+      :app_secret => ENV["FACEBOOK_APP_SECRET_TEST"]
+    },
+    :google_oauth2 => {
+      :app_id => ENV["GOOGLE_APP_ID_TEST"],
+      :app_secret => ENV["GOOGLE_APP_SECRET_TEST"]
     }
   }
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 Rails.application.config.middleware.use OmniAuth::Builder do
   Redu::Application.config.omniauth.each do |service, app_info|
-    provider service, app_info[:app_id], app_info[:app_secret] 
+    provider service, app_info[:app_id], app_info[:app_secret], :scope => 'email', :display => 'popup'
   end
 end

--- a/config/local_env.yml.example
+++ b/config/local_env.yml.example
@@ -1,0 +1,38 @@
+# Rename this file to local_env.yml
+# Add account settings and API keys here.
+# This file should be listed in .gitignore to keep your settings secret!
+# Each entry gets set as a local environment variable.
+# This file overrides ENV variables in the Unix shell.
+# For example, setting:
+# GMAIL_USERNAME: 'Your_Gmail_Username'
+# makes 'Your_Gmail_Username' available as ENV["GMAIL_USERNAME"]
+
+# Development
+FACEBOOK_APP_ID_DEV: '142857189169463'
+FACEBOOK_APP_SECRET_DEV: 'ea0f249a4df83b250c3364ccf097f35c'
+GOOGLE_APP_ID_DEV: '422599681328-hgh6eg6gbv0o1f72v2gopgeouib07ng0.apps.googleusercontent.com'
+GOOGLE_APP_SECRET_DEV: '10YNh1lv7KUaKQvpZXSHz_99'
+
+# Performance
+FACEBOOK_APP_ID_PERF: '142857189169463'
+FACEBOOK_APP_SECRET_PERF: 'ea0f249a4df83b250c3364ccf097f35c'
+GOOGLE_APP_ID_PERF: '422599681328-hgh6eg6gbv0o1f72v2gopgeouib07ng0.apps.googleusercontent.com'
+GOOGLE_APP_SECRET_PERF: '10YNh1lv7KUaKQvpZXSHz_99'
+
+# Production
+FACEBOOK_APP_ID_PROD: '191555477625856'
+FACEBOOK_APP_SECRET_PROD: '27e285f90a3ee1db7a3b61641ae14694'
+GOOGLE_APP_ID_PROD: '422599681328-hgh6eg6gbv0o1f72v2gopgeouib07ng0.apps.googleusercontent.com'
+GOOGLE_APP_SECRET_PROD: '10YNh1lv7KUaKQvpZXSHz_99'
+
+# Staging
+FACEBOOK_APP_ID_STAG: '142857189169463'
+FACEBOOK_APP_SECRET_STAG: 'ea0f249a4df83b250c3364ccf097f35c'
+GOOGLE_APP_ID_STAG: '422599681328-hgh6eg6gbv0o1f72v2gopgeouib07ng0.apps.googleusercontent.com'
+GOOGLE_APP_SECRET_STAG: '10YNh1lv7KUaKQvpZXSHz_99'
+
+# Test
+FACEBOOK_APP_ID_TEST: '142857189169463'
+FACEBOOK_APP_SECRET_TEST: 'ea0f249a4df83b250c3364ccf097f35c'
+GOOGLE_APP_ID_TEST: '422599681328-hgh6eg6gbv0o1f72v2gopgeouib07ng0.apps.googleusercontent.com'
+GOOGLE_APP_SECRET_TEST: '10YNh1lv7KUaKQvpZXSHz_99'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Redu::Application.routes.draw do
     get '/auth/:provider/callback' => 'authentications#create', :as => :omniauth_auth
     get '/auth/failure' => 'authentications#fallback', :as => :omniauth_fallback
     get 'auth/facebook', :as => :facebook_authentication
+    get 'auth/google_oauth2', :as => :google_authentication
 
     get '/recover_username_password' => 'users#recover_username_password',
       :as => :recover_username_password


### PR DESCRIPTION
…via Google e Facebook

Adição da estratégia de autenticação da Google OAuth2 via a gem omniauth-google-oauth2 e alguns botõs para a efetuação do login.

Também foi alterada a forma de leitura das chaves das APIS do Google e do Facebook, que agora lêem variáveis de ambiente. Um arquivo de exemplo config/local_env.yml.example foi adicionado. Para usá-lo, já que agora a aplicação tenta ler o arquivo 'config/local_env.yml', basta tirar o '.example' do fim do nome e reiniciar a aplicação para que as variáveis sejam lidas. As chaves no exemplo atual funcionam para testes locais. Há um problema, porém, pois as do Facebook funcionam quando a url do navegador é 0.0.0.0/3000, já a do Google funciona com localhost:3000. É preciso corrigir (trocar) a aplicação no Facebook para que ela também aceite requisições de localhost.

Acho que essa mudança também deve propagar para os documentos de instalação do OpenRedu, já que preparar as variáveis de ambiente do login é um passo a mais no setup.

Os botões ainda não estão com o layout final, já que seria bom customizar no redu bootstrap.
# 
- [x] Permitir login via Google
- [ ] Ajustar configuração da autenticação com FB via acesso local (`localhost` x `0.0.0.0`)
- [ ] Atualizar a chave de configuração da autenticação com FB para produção
- [ ] Ajustar interface gráfica (layout de botões) -- via Redu Bootstrap
- [ ] Ajustar alguns passos no OpenRedu-Setup-(Ubuntu)
