### PR TITLE
Atualizando termos de uso, mudando o nome da aplicação de Redu para O…

### DIFF
--- a/app/views/shared/_tos.html.erb
+++ b/app/views/shared/_tos.html.erb
@@ -70,7 +70,7 @@
 
 <p>São aceitas comunicações de violações e solicitações de providências pelos seguintes endereços:</p>
 
-<p><%= mail_to "contato@OpenRedu.com.br" %></p>
+<p><%= mail_to "contato@redu.com.br" %></p>
 
 <p>Comunicações de violações e solicitações de providências enviadas por outros canais não serão recebidas. Comunicações de violações e solicitações de providências enviadas sem identificação completa do requerente e descrição detalhada e justificada da violação não serão atendidas. O OpenRedu responderá preferencialmente ao endereço de e-mail do requerente, indicado na sua mensagem enviada pelos canais acima.</p>
 

--- a/app/views/shared/_tos.html.erb
+++ b/app/views/shared/_tos.html.erb
@@ -70,7 +70,7 @@
 
 <p>São aceitas comunicações de violações e solicitações de providências pelos seguintes endereços:</p>
 
-<p><%= mail_to "contato@redu.com.br" %></p>
+<p><%= mail_to "contato@openredu.com" %></p>
 
 <p>Comunicações de violações e solicitações de providências enviadas por outros canais não serão recebidas. Comunicações de violações e solicitações de providências enviadas sem identificação completa do requerente e descrição detalhada e justificada da violação não serão atendidas. O OpenRedu responderá preferencialmente ao endereço de e-mail do requerente, indicado na sua mensagem enviada pelos canais acima.</p>
 

--- a/app/views/shared/_tos.html.erb
+++ b/app/views/shared/_tos.html.erb
@@ -2,26 +2,26 @@
   Termos de Uso.
 %>
 
-<p>Este documento contém os Termos de Uso do ambiente Redu, cuja aceitação plena e integral é requisito para todos os seus participantes. Ele inclui, além dos termos gerais, os termos de limitação de responsabilidade, a política de privacidade e confidencialidade, as licenças de livre uso do conteúdo, e as informações sobre como reportar violações.</p>
+<p>Este documento contém os Termos de Uso do ambiente OpenRedu, cuja aceitação plena e integral é requisito para todos os seus participantes. Ele inclui, além dos termos gerais, os termos de limitação de responsabilidade, a política de privacidade e confidencialidade, as licenças de livre uso do conteúdo, e as informações sobre como reportar violações.</p>
 
-<p>O uso do Redu implica o reconhecimento e a plena aceitação dos termos a seguir.</p>
+<p>O uso do OpenRedu implica o reconhecimento e a plena aceitação dos termos a seguir.</p>
 
-<p>Todos os recursos do Redu  que permitem a exibição de conteúdo de autoria de seus usuários são espaços reservados para que sejam trocadas informações educacionais. Todos os que publicam conteúdos são informados destes Termos de Uso no momento de publicação de conteúdos, e sua participação no Redu é o reconhecimento da aceitação dos mesmos.</p>
+<p>Todos os recursos do OpenRedu  que permitem a exibição de conteúdo de autoria de seus usuários são espaços reservados para que sejam trocadas informações educacionais. Todos os que publicam conteúdos são informados destes Termos de Uso no momento de publicação de conteúdos, e sua participação no OpenRedu é o reconhecimento da aceitação dos mesmos.</p>
 
 <p>O usuário reconhece que todas as contribuições são bem-vindas, desde que respeitadas as condições descritas nestes Termos de Uso.</p>
 
-<p>Ao visitar, ler, ou interagir com os recursos disponibilizados pelo Redu, você está aceitando todas as condições mencionadas nestes Termos de Uso, com destaque para as seguintes condições gerais:</p>
+<p>Ao visitar, ler, ou interagir com os recursos disponibilizados pelo OpenRedu, você está aceitando todas as condições mencionadas nestes Termos de Uso, com destaque para as seguintes condições gerais:</p>
 
 <ol>
   <li>O reconhecimento de que não há presunção de anonimato, e de que o conteúdo postado é de sua inteira responsabilidade, não podendo os autores e mantenedores do site serem responsabilizados por quaisquer fatos decorrentes da postagem desse conteúdo.</li>
-  <li>O reconhecimento de que as postagens devem obedecer ao escopo e ao objetivo do Redu, mantendo-se dentro do assunto em que estão inseridas, acatando as definições adotadas pelo Redu e sem induzir outros usuários a atitudes tecnicamente incorretas, e sem conter ofensas, vocabulário ofensivo ou desrespeitoso a terceiros, incluindo calúnias, injúrias e difamações.</li>
+  <li>O reconhecimento de que as postagens devem obedecer ao escopo e ao objetivo do OpenRedu, mantendo-se dentro do assunto em que estão inseridas, acatando as definições adotadas pelo OpenRedu e sem induzir outros usuários a atitudes tecnicamente incorretas, e sem conter ofensas, vocabulário ofensivo ou desrespeitoso a terceiros, incluindo calúnias, injúrias e difamações.</li>
   <li>O reconhecimento de que a permanência de conteúdos no site deve ser encarada como um privilégio e que, em consequência disso, os operadores do site tomarão as providências necessárias para garantir as condições destes Termos de Uso, sempre que solicitado por alguma parte ofendida, ou que seja verificada a ocorrência de violação, a critério da administração do site.</li>
   <li>O reconhecimento de que a licença livre adotada em seu conteúdo será escolhida no momento da publicação e que ela será mencionada explicitamente na página de publicação do conteúdo</li>
   <li>O reconhecimento de que o conteúdo deve estar de acordo com a legislação em vigor, sem material que possa ser considerado ilegal ou que incite ou favoreça práticas em desacordo com a legislação. E que toda informação registrada usando os recursos do site é considerada como pública, sem nenhum tipo de confidencialidade.</li>
-  <li>Para se identificar como autor, poderá o criador do conteúdo enviado ao Redu usar seu nome civil, completo ou abreviado até por suas iniciais, pseudônimo ou qualquer outro sinal convencional (Lei 9.610/1998, Art. 12). Não são permitidos conteúdos de autor não identificado. Embora não seja possível tecnicamente garantir que os pseudônimos e endereços de e-mail fornecidos sejam sempre corretos e identificáveis, a administração do site solicita seu correto preenchimento em todas as ocasiões, e identifica o autor através do registro (e possível exibição) do endereço de origem e do horário de cada postagem.</li>
+  <li>Para se identificar como autor, poderá o criador do conteúdo enviado ao OpenRedu usar seu nome civil, completo ou abreviado até por suas iniciais, pseudônimo ou qualquer outro sinal convencional (Lei 9.610/1998, Art. 12). Não são permitidos conteúdos de autor não identificado. Embora não seja possível tecnicamente garantir que os pseudônimos e endereços de e-mail fornecidos sejam sempre corretos e identificáveis, a administração do site solicita seu correto preenchimento em todas as ocasiões, e identifica o autor através do registro (e possível exibição) do endereço de origem e do horário de cada postagem.</li>
   <li>A remoção ou edição de conteúdos por iniciativa de seu próprio autor é facultada de acordo com as opções disponíveis na ferramenta de gestão de conteúdo, se houver. Outros casos de edição ou alteração podem ser solicitados pelo autor do conteúdo, de forma fundamentada, via formulário de contato. O atendimento, nestes casos, estará sujeito a análise sob aspectos técnicos e da manutenção da qualidade das discussões.</li>
   <li>Tentativas de abuso do sistema de moderação, ou de abuso sistemático e repetitivo destes Termos de Uso, incluindo a reinclusão de material que já tenha sido previamente moderado, serão prevenidas ou corrigidas por intermédio dos recursos técnicos que estiverem disponíveis, sempre que possível. O protesto contra a moderação pode ser encaminhado pelo formulário de contato, mas será considerado off-topic nas áreas de discussão.</li>
-  <li>Logins e identificações de usuário considerados inadequados pela administração do Redu (incluindo casos de mais de um login para o mesmo usuário, ofensas, identificações que possam levar os demais usuários a acreditar que você fala em nome de outra pessoa ou organização) podem ser desativados, removidos, ter seus privilégios de acesso reduzidos ou ter seu conteúdo tornado inacessível sem aviso. O login registrado no Redu, ou a disponibilização de conteúdo no mesmo, não geram nenhum direito de suporte, não cabendo qualquer tipo de reparação, compensação ou outra obrigação do Redu em caso de cancelamento, suspensão, perda, indisponibilidade ou outra situação adversa que afete o acesso, os dados ou o conteúdo do usuário.</li>
+  <li>Logins e identificações de usuário considerados inadequados pela administração do OpenRedu (incluindo casos de mais de um login para o mesmo usuário, ofensas, identificações que possam levar os demais usuários a acreditar que você fala em nome de outra pessoa ou organização) podem ser desativados, removidos, ter seus privilégios de acesso OpenReduzidos ou ter seu conteúdo tornado inacessível sem aviso. O login registrado no OpenRedu, ou a disponibilização de conteúdo no mesmo, não geram nenhum direito de suporte, não cabendo qualquer tipo de reparação, compensação ou outra obrigação do OpenRedu em caso de cancelamento, suspensão, perda, indisponibilidade ou outra situação adversa que afete o acesso, os dados ou o conteúdo do usuário.</li>
 </ol>
 
 <p>Também deverão ser seguidas as seguintes orientações:</p>
@@ -37,25 +37,25 @@
 
 <h5 class="section"><strong>Limitação de responsabilidade</strong></h5 class="section">
 
-<p>Em nenhuma situação o Redu, seus autores, editores ou mantenedores serão responsáveis por quaisquer danos, prejuízos ou outro efeito, direto ou indireto, relacionados ao uso, por parte de seus usuários, leitores ou de qualquer outra pessoa, deste website, de seu conteúdo ou de qualquer outro website aqui mencionado.</p>
+<p>Em nenhuma situação o OpenRedu, seus autores, editores ou mantenedores serão responsáveis por quaisquer danos, prejuízos ou outro efeito, direto ou indireto, relacionados ao uso, por parte de seus usuários, leitores ou de qualquer outra pessoa, deste website, de seu conteúdo ou de qualquer outro website aqui mencionado.</p>
 
-<p>Em especial, o Redu não classifica nem analisa o conteúdo que seus usuários e leitores acrescentam como comentários ou como participações nos fóruns e demais áreas do site, mediadas ou não. Todo autor de conteúdo exibido no Redu retém os seus direitos e responsabilidades autorais, nos termos da Lei 9.610/1998, sem prejuízo dos termos de licenciamento de livre uso, conforme exposto nestes Termos de Uso, no item “Licença de uso do conteúdo”, abaixo.</p>
+<p>Em especial, o OpenRedu não classifica nem analisa o conteúdo que seus usuários e leitores acrescentam como comentários ou como participações nos fóruns e demais áreas do site, mediadas ou não. Todo autor de conteúdo exibido no OpenRedu retém os seus direitos e responsabilidades autorais, nos termos da Lei 9.610/1998, sem prejuízo dos termos de licenciamento de livre uso, conforme exposto nestes Termos de Uso, no item “Licença de uso do conteúdo”, abaixo.</p>
 
 <h5 class="section"><strong>Política de privacidade e confidencialidade</strong></h5 class="section">
 
-<p>O Redu não deseja nem aceita receber ou intermediar material confidencial por nenhuma das ferramentas oferecidas ou mencionadas no site, nem pelos contatos de sua equipe. Toda informação enviada pelos recursos do site ou recebida por intermédio deles ou dos endereços de contato de sua equipe será tratada como não sendo confidencial, independente de qualquer declaração do autor da comunicação que não tenha sido previamente aceita por escrito pelos responsáveis pelo Redu</p>
+<p>O OpenRedu não deseja nem aceita receber ou intermediar material confidencial por nenhuma das ferramentas oferecidas ou mencionadas no site, nem pelos contatos de sua equipe. Toda informação enviada pelos recursos do site ou recebida por intermédio deles ou dos endereços de contato de sua equipe será tratada como não sendo confidencial, independente de qualquer declaração do autor da comunicação que não tenha sido previamente aceita por escrito pelos responsáveis pelo OpenRedu</p>
 
-<p>O envio de material para o site implica em a parte que está enviando aceitar responsabilidade plena e não compartilhada com o Redu quanto ao conteúdo enviado, e quanto às implicações legais e morais de sua eventual publicação.</p>
+<p>O envio de material para o site implica em a parte que está enviando aceitar responsabilidade plena e não compartilhada com o OpenRedu quanto ao conteúdo enviado, e quanto às implicações legais e morais de sua eventual publicação.</p>
 
 <h5 class="section"><strong>Licença de uso do conteúdo</strong></h5 class="section">
 
-<p>Todo autor de conteúdo exibido no Redu retém os seus direitos e responsabilidades autorais, nos termos da Lei 9.610/1998, sem prejuízo dos termos de licenciamento de livre uso, expostos a seguir.</p>
+<p>Todo autor de conteúdo exibido no OpenRedu retém os seus direitos e responsabilidades autorais, nos termos da Lei 9.610/1998, sem prejuízo dos termos de licenciamento de livre uso, expostos a seguir.</p>
 
-<p>Exceto quando mencionado explicitamente, ou quando se tratar de citação (adequadamente indicada no corpo do texto, por intermédio de tipo diferenciado, aspas e/ou margem esquerda adicional) de material alheio ou ilustração, nos limites estabelecidos pela Lei 9.610/98, todo o conteúdo textual original do Redu está disponível livremente para leitura, uso, redistribuição ou modificação, entre outros direitos, conforme definido na licença Creative Commons.</p>
+<p>Exceto quando mencionado explicitamente, ou quando se tratar de citação (adequadamente indicada no corpo do texto, por intermédio de tipo diferenciado, aspas e/ou margem esquerda adicional) de material alheio ou ilustração, nos limites estabelecidos pela Lei 9.610/98, todo o conteúdo textual original do OpenRedu está disponível livremente para leitura, uso, redistribuição ou modificação, entre outros direitos, conforme definido na licença Creative Commons.</p>
 
 <h5 class="section"><strong>Como reportar violações</strong></h5 class="section">
 
-<p>Se algum conteúdo do Redu violar algum direito seu ou a legislação aplicável, entre em contato pelos endereços indicados abaixo, mencionando de forma específica e detalhada:</p>
+<p>Se algum conteúdo do OpenRedu violar algum direito seu ou a legislação aplicável, entre em contato pelos endereços indicados abaixo, mencionando de forma específica e detalhada:</p>
 
 <ul>
   <li>o título da página específica em que se encontra a violação;</li>
@@ -66,23 +66,23 @@
   <li>as suas informações de contato, incluindo e-mail</li>
 </ul>
 
-<p>De posse destas informações, o Redu poderá analisar e resolver a questão tão breve quanto possível. Caso a informação esteja incompleta, ou com detalhamento insuficiente, o Redu entrará em contato para solicitar a complementação, possivelmente atrasando a providência desejada.</p>
+<p>De posse destas informações, o OpenRedu poderá analisar e resolver a questão tão breve quanto possível. Caso a informação esteja incompleta, ou com detalhamento insuficiente, o OpenRedu entrará em contato para solicitar a complementação, possivelmente atrasando a providência desejada.</p>
 
 <p>São aceitas comunicações de violações e solicitações de providências pelos seguintes endereços:</p>
 
-<p><%= mail_to "contato@redu.com.br" %></p>
+<p><%= mail_to "contato@OpenRedu.com.br" %></p>
 
-<p>Comunicações de violações e solicitações de providências enviadas por outros canais não serão recebidas. Comunicações de violações e solicitações de providências enviadas sem identificação completa do requerente e descrição detalhada e justificada da violação não serão atendidas. O Redu responderá preferencialmente ao endereço de e-mail do requerente, indicado na sua mensagem enviada pelos canais acima.</p>
+<p>Comunicações de violações e solicitações de providências enviadas por outros canais não serão recebidas. Comunicações de violações e solicitações de providências enviadas sem identificação completa do requerente e descrição detalhada e justificada da violação não serão atendidas. O OpenRedu responderá preferencialmente ao endereço de e-mail do requerente, indicado na sua mensagem enviada pelos canais acima.</p>
 
 <h5 class="section"><strong>Inexistência de Vínculo</strong></h5 class="section">
 
-<p>Estes Termos de Uso não importam na criação de qualquer vínculo trabalhista, societário, de parceria ou associativo entre o usuário-colaborador e o Redu, sendo excluídas quaisquer presunções de solidariedade entre ambos no cumprimento de suas obrigações.</p>
+<p>Estes Termos de Uso não importam na criação de qualquer vínculo trabalhista, societário, de parceria ou associativo entre o usuário-colaborador e o OpenRedu, sendo excluídas quaisquer presunções de solidariedade entre ambos no cumprimento de suas obrigações.</p>
 
 <h5 class="section"><strong>Disposições Finais</strong></h5 class="section">
 
 <p>Estas Condições Gerais serão regidas e interpretadas de acordo com a legislação brasileira. Fica eleito o Foro da Comarca de Recife, Estado de Pernambuco, para dirimir questões relativas a estas Condições Gerais, com renúncia expressa a qualquer outro.</p>
 
-<p>Estes termos de uso podem ser modificados pelo Redu, e as modificações terão efeito a partir da data de sua publicação no website, mediante a sua comunicação em local que seja de fácil identificação para o usuário.</p>
+<p>Estes termos de uso podem ser modificados pelo OpenRedu, e as modificações terão efeito a partir da data de sua publicação no website, mediante a sua comunicação em local que seja de fácil identificação para o usuário.</p>
 
 <h5 class="section"><strong>Referência</strong></h5 class="section">
 


### PR DESCRIPTION
Este pull request atualiza o documento dos Termos de Uso do OpenRedu, mudando o nome da aplicação de Redu para OpenRedu.

Uma dúvida: A última modificação dos termos de uso foi a [3 anos](https://github.com/OpenRedu/OpenRedu/commit/4f2f5eb59dd69bb823121a672d5ab38840d36dc2). O conteúdo ainda é válido?
