### PR TITLE
Remove image upload from ckeditor

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -53,7 +53,7 @@ CKEDITOR.editorConfig = function( config )
     { name: 'usability', items: [ 'Maximize' ] },
     { name: 'styles', items: [ 'Font', 'FontSize' ] },
     { name: 'colors', items: [ 'TextColor', 'BGColor' ] },
-    { name: 'insert', items: [ 'Image', 'Link', 'Table', 'HorizontalRule', 'SpecialChar' ] },
+    { name: 'insert', items: [ 'Link', 'Table', 'HorizontalRule', 'SpecialChar' ] },
     { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ], items: [ 'Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', '-', 'RemoveFormat' ] }
   ];
 
@@ -65,7 +65,7 @@ CKEDITOR.editorConfig = function( config )
     ['NumberedList','BulletedList','-','Outdent','Indent','Blockquote'],
     ['JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock'],
     ['Link','Unlink','Anchor'],
-    ['Image','Table','HorizontalRule','Smiley','SpecialChar','PageBreak'],
+    ['Table','HorizontalRule','Smiley','SpecialChar','PageBreak'],
     '/',
     ['Styles','Format','Font','FontSize'],
     ['TextColor','BGColor'],


### PR DESCRIPTION
According to https://github.com/galetahub/ckeditor/issues/752 and
https://github.com/rails/rails/commit/0189f4db6fe518de8909b66b7f30046bac52dedc#diff-9c7c8274426cb68629b863c3ddf57b2a would be necessary to upgrade both ckeditor gem and rails.
As a workaroud the image upload feature is being removed, we recommend to use
the url option.

Fix #195

Ref: #174