### PR TITLE
WIP: CMR/activate-all-users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ActiveRecord::Base
 
   # CALLBACKS
   before_create :make_activation_code
-  after_create  :update_last_login
+  after_create  :update_last_login, :activate
   before_validation :strip_whitespace
   after_commit on: :create do
     environment = Environment.find_by_path('ava-redu')

--- a/config/application.rb
+++ b/config/application.rb
@@ -256,16 +256,19 @@ module Redu
     }
 
     # SMTP settings
-    config.action_mailer.smtp_settings = {
-      address: ENV['SMTP_ADDR'],
-      port: 465,
-      domain: ENV['SMTP_DOMAIN'],
-      authentication: "plain",
-      enable_starttls_auto: true,
-      user_name: ENV['SMTP_USER'],
-      password: ENV['SMTP_PASSWD'],
-      openssl_verify_mode: "none"
-    }
+    # config.action_mailer.smtp_settings = {
+    #   address: ENV['SMTP_ADDR'],
+    #   port: 465,
+    #   domain: ENV['SMTP_DOMAIN'],
+    #   authentication: "plain",
+    #   enable_starttls_auto: true,
+    #   user_name: ENV['SMTP_USER'],
+    #   password: ENV['SMTP_PASSWD'],
+    #   openssl_verify_mode: "none"
+    # }
+    config.action_mailer.delivery_method = :test
+    config.action_mailer.perform_deliveries = false
+    config.action_mailer.raise_delivery_errors = false
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
#### * Para atender as necessidade do Colégio Militar do Recife, foram solicitadas as seguintes customizações na instância:

- [ ] Ativar conta do usuário no momento do cadastro, sem necessidade de confirmação por e-mail
- [ ] Desativar envio de e-mail via SMTP

> TODO: Verificar problemas na suite de teste.