### PR TITLE
Corrigir título da página Esqueci a Senha

### DIFF
--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -257,6 +257,8 @@ module BaseHelper
           title = @user.login
           title += ' - ' + app_base + tagline
           @canonical_url = user_url(@user)
+        elsif @recover_password
+          title = t(:recover_password) + ' - ' + app_base + tagline
         else
           title = t(:showing_users) + ' - ' + app_base + tagline
         end

--- a/lang/ui/pt-BR.yml
+++ b/lang/ui/pt-BR.yml
@@ -951,6 +951,8 @@ pt-BR:
   for_detailed_contest_rules: "For detailed contest rules,"
   #en: for_more_information_on_tags_check_out_the: For more information on tags check out the
   for_more_information_on_tags_check_out_the: For more information on tags check out the
+  #en: recover_password: Recover Password
+  recover_password: Recuperar Senha
   #en: forgot_your_password: Forgot your password?
   forgot_your_password: Esqueceu a senha?
   #en: forgot_your_username: Forgot your username?


### PR DESCRIPTION
A página Esqueci a Senha estava com o título "Showing users". Alterado título para "Recuperar Senha" como descrito na issue #36.