### PR TITLE
Corrigir preenchimento do campo de celular

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -200,4 +200,13 @@
   <div class="content-section clearfix">
     <%= f.submit t(:save_changes), :class => "button-primary pull-right" %>
   </div>
+
+  # Mask para o numero usando o jquery mask
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.js"></script>
+  <script>
+    $(document).ready(function(){
+      $('.form-config-mobile').mask('+55 (00) 00000-0000');
+    });
+  </script>
 <% end %>


### PR DESCRIPTION
### Nesse PR:
Com essa mudança foi possível auto preencher o código do pais (+55) e caracteres do padrão de telefone.

![Screencast from 04-05-2022 22 31 14](https://user-images.githubusercontent.com/37005544/166852121-03fba5b1-62fc-49c2-b1f1-16ebcd4edff6.gif)

### Resolução:
Importar o jQuery Mask Plugin com a função .mask()

### Issue Relacionada:
#304 