### PR TITLE
Adicionar página 404 para usuários

### DIFF
--- a/app/assets/stylesheets/not_found.scss
+++ b/app/assets/stylesheets/not_found.scss
@@ -1,7 +1,7 @@
 .error-container{
     width:100%;
   
-    min-height: 250px;
+    min-height: 350px;
     height:100%;
   
     display:flex;

--- a/app/assets/stylesheets/not_found.scss
+++ b/app/assets/stylesheets/not_found.scss
@@ -1,0 +1,14 @@
+.error-container{
+    width:100%;
+  
+    min-height: 250px;
+    height:100%;
+  
+    display:flex;
+    align-items:center;
+    justify-content: center;
+  }  p{
+      color: #4f4f4f;
+      font-size: 1.4rem;
+      font-weight: 600;
+  }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,7 @@ class UsersController < BaseController
     :find_by => :login
 
   rescue_from CanCan::AccessDenied, :with => :deny_access
+  rescue_from ActiveRecord::RecordNotFound, :with => :not_found
 
   before_filter :remove_errors_field, only: :create
 
@@ -431,6 +432,10 @@ class UsersController < BaseController
 
   def new
     redirect_to application_path(:anchor => "modal-sign-up")
+  end
+  
+  def not_found
+    render 'users/not_found', :layout => 'new_application'
   end
 
   protected

--- a/app/views/users/not_found.html.erb
+++ b/app/views/users/not_found.html.erb
@@ -1,0 +1,11 @@
+<%= stylesheet_link_tag :not_found %>
+
+<%#
+  Página de usuário não encontrado
+%>
+<div class="home-left-sidebar">
+</div>
+
+<div class="error-container">
+  <p>Usuário não encontrado</p>
+</div>


### PR DESCRIPTION
Foi implementada ao Controller do usuário uma resposta para a requisição de um usuário não existente e ao View do mesmo uma página personalizada para ocorrência do erro 404, onde ao essa pesquisa anteriormente mostrava uma página sem nenhum erro aparente ou alguma informação condizendo que não existia aquele usuário.
![user_not_found](https://user-images.githubusercontent.com/39523817/168000452-d4350291-bdd4-492b-ad59-4c830cce6936.png)

A implementação buscou solucionar a issue #247 