### PR TITLE
Ajeitar validação de nome e sobrenome do usuário

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,8 +160,8 @@ class User < ActiveRecord::Base
   validates_format_of :mobile,
                       with: /^\+\d{2}\s\(\d{2}\)\s\d{4,5}-\d{3,4}$/,
                       allow_blank: true
-  validates_format_of :first_name, with: /^\S(\S|\s)*\S$/
-  validates_format_of :last_name, with: /^\S(\S|\s)*\S$/
+  validates_format_of :first_name, with: /^[a-zA-Z0-9\-\_]{1}([a-zA-Z0-9\-\_ ]*)[a-zA-Z0-9\-\_]{1}$/
+  validates_format_of :last_name, with: /^[a-zA-Z0-9\-\_]{1}([a-zA-Z0-9\-\_ ]*)[a-zA-Z0-9\-\_]{1}$/
   validates_length_of :first_name, maximum: 25
   validates_length_of :last_name, maximum: 25
   validates :password,


### PR DESCRIPTION
Foi ajeitado o Regex de validação dos campos de nome e sobrenome do usuário seguindo as regras seguintes:

O nome pode ser formado apenas por:
- Letras, 
- Números,
- Traço e sublinhado. 
- Não deixe espaços no início ou final.
<p align="center">
<img width="308" alt="validation" src="https://user-images.githubusercontent.com/39523817/168151658-f8a653f4-c0c7-4da5-bb6f-f48a6b81c14f.png">
</p>

Agora ele está seguindo esta regra citada acima à risca, não permitindo a inserção de outros caracteres especiais, anteriormente permitidos, com exceção de traços e sublinhados, como também, não permitindo espaços no final ou inicio destes campos, que era a única regra que estava sendo imposta pelo Regex antes desta implementação:
<p align="center">
<img width="500" alt="validation" src="https://user-images.githubusercontent.com/39523817/168152214-5ee9cf4e-c2fd-4948-a36b-ee940421b21c.png">
</p>

Esta implementação buscou solucionar a issue https://github.com/Openredu/Openredu/issues/37